### PR TITLE
Introduce ty

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -63,6 +63,11 @@
       ]
     },
     {
+      "matchPackageNames": ["pydantic"],
+      "allowedVersions": "<2.13",
+      "description": "Until https://github.com/ultimate-notion/ultimate-notion/issues/189 is fixed"
+    },
+    {
       // Group pep621 and pre-commit updates into a single PR so the
       // pre-commit hook revs and pyproject.toml deps land together.
       "matchManagers": [

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -19,6 +19,12 @@ jobs:
       - name: Get source code
         uses: actions/checkout@v6
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: 'uv.lock'
+
       - name: Run prek
         uses: j178/prek-action@v2
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -161,9 +161,25 @@ repos:
           - types-requests~=2.33
           - ultimate-notion~=0.9.6
 
-  - repo: https://github.com/osprey-oss/deptry
-    rev: 0.25.1
+  - repo: local
+    hooks:
+      - id: ty-check
+        name: ty check
+        description: Type check with ty.
+        entry: uv run ty check
+        language: system
+        pass_filenames: false
+        require_serial: true
+        types:
+         - python
+
+  - repo: local
     hooks:
       - id: deptry
-        stages:
-          - manual
+        name: deptry
+        entry: uv run deptry .
+        language: system
+        pass_filenames: false
+        types:
+         - python
+        always_run: true

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,6 @@
 {
   "recommendations": [
+    "astral-sh.ty",
     "charliermarsh.ruff",
     "dotenv.dotenv-vscode",
     "eamodio.gitlens",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,8 @@
   "files.associations": {
     "renovate.json": "jsonc"
   },
+  "python.languageServer": "Pylance",
+  "ty.disableLanguageServices": true,
   "flake8.importStrategy": "fromEnvironment",
   "mypy-type-checker.importStrategy": "fromEnvironment",
   "pylint.importStrategy": "fromEnvironment",

--- a/justfile
+++ b/justfile
@@ -69,6 +69,7 @@ sync:
 [group('QA')]
 format:
     @{{ title }} "Running automatic formatting/cleanup..."
+    -uv run ty check --fix
     -uv run ruff check --fix
     uv run ruff format
 
@@ -84,6 +85,7 @@ lint:
 [group('QA')]
 type-check:
     @{{ title }} "Running static type checking with mypy..."
+    uv run ty check
     uv run mypy notion_videogames
 
 [doc('Run all QA checks')]

--- a/notion_videogames/igdb_notion.py
+++ b/notion_videogames/igdb_notion.py
@@ -4,31 +4,35 @@ from __future__ import annotations
 import functools
 import itertools
 import urllib.parse
-from typing import Final, TypeVar, override
+from typing import TYPE_CHECKING, Final, TypeVar, cast, override
 
-import betterproto2
 import ultimate_notion as uno
+from betterproto2 import Message
 from ultimate_notion import PropType, props
 
 from notion_videogames import notion
 from notion_videogames.proto import proto
 
-T = TypeVar("T", bound=betterproto2.Message)
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+T = TypeVar("T", bound=Message)
 
 # https://developers.notion.com/reference/request-limits
 MAX_RELATION_PAGES: Final[int] = 100
 MAX_TEXT_LENGTH: Final[int] = 2000
 
 
-def _hash(self: betterproto2.Message) -> int:
-    return hash(bytes(self))
-
-
 # Monkeypatch betterproto2.Message adding a __hash__ method so instances can be used in lru_cache
-betterproto2.Message.__hash__ = _hash  # type: ignore[assignment,method-assign]
+if cast("Callable[[object], int] | None", Message.__hash__) is None:
+
+    def _hash(self: Message) -> int:
+        return hash(bytes(self))
+
+    Message.__hash__ = _hash  # type: ignore[assignment] # ty: ignore[invalid-assignment]
 
 
-def add_https_scheme[AnyStr: (bytes, str)](url: AnyStr) -> AnyStr:
+def add_https_scheme(url: str) -> str:
     parsed_url = urllib.parse.urlparse(url)
 
     if parsed_url.scheme:
@@ -36,11 +40,7 @@ def add_https_scheme[AnyStr: (bytes, str)](url: AnyStr) -> AnyStr:
         return url
 
     # If there's no scheme, add 'https'
-    new_components = (
-        "https" if isinstance(url, str) else b"https",  # type: ignore[redundant-expr]
-        *parsed_url[1:],  # type: ignore[has-type]
-    )
-    return urllib.parse.urlunparse(new_components)  # type: ignore[no-any-return]
+    return urllib.parse.urlunparse(("https", *parsed_url[1:]))
 
 
 class IGDBNotionPage(notion.NotionPageType[T]):

--- a/notion_videogames/main.py
+++ b/notion_videogames/main.py
@@ -204,7 +204,7 @@ if __name__ == "__main__":
     igdb = IGDBWrapper(IGDB_CLIENT_ID, igdb_token)
 
     # Initialize Notion client
-    with uno.Session.get_or_create() as notion_session:
+    with uno.Session.get_or_create() as notion_session:  # ty: ignore[invalid-context-manager]
         pages: list[uno.Page] = list(notion_session.get_db(SOURCE_DB_ID).get_all_pages())
 
         url_path_parts = get_url_path_parts(str(page.props["URL"]) for page in pages)

--- a/notion_videogames/notion.py
+++ b/notion_videogames/notion.py
@@ -9,8 +9,7 @@ import tenacity
 import ultimate_notion as uno
 from notion_client.errors import HTTPResponseError, RequestTimeoutError
 from pydantic import ValidationError
-from ultimate_notion.core import Wrapper
-from ultimate_notion.emoji import CustomEmoji, Emoji
+from ultimate_notion.emoji import CustomEmoji, Emoji, EmojiBase
 from ultimate_notion.errors import ReadOnlyPropertyError, SchemaError
 from ultimate_notion.obj_api.core import Unset, UnsetType
 
@@ -29,9 +28,9 @@ class NotionPageType[T](abc.ABC):
     update: ClassVar[bool] = False
     """Whether pages that already exist should be updated"""
 
-    @classmethod
+    @staticmethod
     @abc.abstractmethod
-    def get_populated_properties_dict(cls, data: T) -> dict[str, props.PropertyValue]: ...
+    def get_populated_properties_dict(data: T) -> dict[str, props.PropertyValue]: ...
 
     @classmethod
     @abc.abstractmethod
@@ -98,14 +97,14 @@ class NotionPageType[T](abc.ABC):
         cover: uno.AnyFile | UnsetType | None = Unset,
         icon: uno.AnyFile | Emoji | CustomEmoji | str | UnsetType | None = Unset,
     ) -> None:
-        if isinstance(icon, str) and not isinstance(icon, (Emoji, CustomEmoji)):
+        if isinstance(icon, str) and not isinstance(icon, EmojiBase):
             icon = Emoji(icon)
 
         uno.Session.get_active().api.pages.update(
             page.obj_ref if isinstance(page, uno.Page) else page,
             properties=cls.validate_and_build_schema_model(data).to_dict(),
             cover=cover.obj_ref if isinstance(cover, uno.AnyFile) else cover,
-            icon=icon.obj_ref if isinstance(icon, Wrapper) else icon,
+            icon=icon.obj_ref if isinstance(icon, (uno.AnyFile, EmojiBase)) else icon,
         )
 
     @classmethod

--- a/notion_videogames/steamspy_notion.py
+++ b/notion_videogames/steamspy_notion.py
@@ -5,6 +5,7 @@ import logging
 from typing import TYPE_CHECKING, Any, ClassVar, Self, override
 
 import requests
+import requests.adapters
 import ultimate_notion as uno
 import urllib3
 from pydantic.dataclasses import dataclass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ dev = [
   "pylint~=4.0",
   "ruff~=0.15",
   "tryceratops~=2.4",
+  "ty~=0.0.32",
   "types-requests~=2.33",
 ]
 # This group lists packages that are not installed in the local environment but are used
@@ -176,3 +177,6 @@ overrides = [
     "notion_videogames.proto.*",
   ], ignore_errors = true },
 ]
+
+[tool.ty]
+analysis.respect-type-ignore-comments = false

--- a/uv.lock
+++ b/uv.lock
@@ -1280,6 +1280,7 @@ dev = [
     { name = "pylint" },
     { name = "ruff" },
     { name = "tryceratops" },
+    { name = "ty" },
     { name = "types-requests" },
 ]
 hooks = [
@@ -1339,6 +1340,7 @@ dev = [
     { name = "pylint", specifier = "~=4.0" },
     { name = "ruff", specifier = "~=0.15" },
     { name = "tryceratops", specifier = "~=2.4" },
+    { name = "ty", specifier = "~=0.0.32" },
     { name = "types-requests", specifier = "~=2.33" },
 ]
 hooks = [
@@ -2159,6 +2161,30 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2a/d3/43c2c190bb6b01decc92d87538b451d7fe8070aaaf18aa1e166bf432754e/tryceratops-2.4.1.tar.gz", hash = "sha256:fbfc14650004e27cd1e55ebb7c76b43ced04a4d3b4cbe42aac9d71e4623ed84d", size = 20595, upload-time = "2024-10-30T16:42:40.97Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/27/b5/88caeba349f17b7fd37b61bc88f81c138b3b5149b4e2a9deec66eaad1bdb/tryceratops-2.4.1-py3-none-any.whl", hash = "sha256:271b92367be89b243918a56361618607d2a9aa4aa4ba766ecfabd5f98c00480c", size = 27378, upload-time = "2024-10-30T16:42:38.914Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/7e/2aa791c9ae7b8cd5024cd4122e92267f664ca954cea3def3211919fa3c1f/ty-0.0.32.tar.gz", hash = "sha256:8743174c5f920f6700a4a0c9de140109189192ba16226884cd50095b43b8a45c", size = 5522294, upload-time = "2026-04-20T19:29:01.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/eb/1075dc6a49d7acbe2584ae4d5b410c41b1f177a5adcc567e09eca4c69000/ty-0.0.32-py3-none-linux_armv6l.whl", hash = "sha256:dacbc2f6cd698d488ae7436838ff929570455bf94bfa4d9fe57a630c552aff83", size = 10902959, upload-time = "2026-04-20T19:28:31.907Z" },
+    { url = "https://files.pythonhosted.org/packages/33/d2/c35fc8bc66e98d1ee9b0f8ed319bf743e450e1f1e997574b178fab75670f/ty-0.0.32-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:914bbc4f605ce2a9e2a78982e28fae1d3359a169d141f9dc3b4c7749cd5eca81", size = 10726172, upload-time = "2026-04-20T19:28:44.765Z" },
+    { url = "https://files.pythonhosted.org/packages/96/32/c827da3ca480456fb02d8cea68a2609273b6c220fea0be9a4c8d8470b86e/ty-0.0.32-py3-none-macosx_11_0_arm64.whl", hash = "sha256:4787ac9fe1f86b1f3133f5c6732adbe2df5668b50c679ac6e2d98cd284da812f", size = 10163701, upload-time = "2026-04-20T19:28:27.005Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/9e/2734478fbdb90c160cb2813a3916a16a2af5c1e231f87d635f6131d781fb/ty-0.0.32-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8ea0a728af99fe40dd744cba6441a2404f80b7f4bde17aa6da393810af5ea57", size = 10656220, upload-time = "2026-04-20T19:29:03.814Z" },
+    { url = "https://files.pythonhosted.org/packages/44/9f/0007da2d35e424debe7e9f86ffbc1ab7f60983cfbc5f0411324ab2de5292/ty-0.0.32-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2850561f9b018ae33d7e5bbfa0ac414d3c518513edcffe43877dc9801446b9c5", size = 10696086, upload-time = "2026-04-20T19:28:46.829Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/5e/ce5fd4ec803222ae3e69a76d2a2db2eed55e19f5b131702b9789ef45f93d/ty-0.0.32-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b5fa2fb3c614349ee211d36476b49d88c5ef79a687cdb91b2872ad023b94d2f8", size = 11184800, upload-time = "2026-04-20T19:28:42.57Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/46/ebcf67a5999421331214aac51a7464db42de2be15bbe929c612a3ed0b039/ty-0.0.32-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2b89969307ab2417d41c9be8059dd79feea577234e1e10d35132f5495e0d42c6", size = 11718718, upload-time = "2026-04-20T19:28:36.433Z" },
+    { url = "https://files.pythonhosted.org/packages/18/2c/2141c86ed0ce0962b45cefb658a95e734f59759d47f20afdcd9c732910a1/ty-0.0.32-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b59868ede9b1d69a088f0d695df52a0061f95fa7baa1d5e0dc6fc9cf06e1334", size = 11346369, upload-time = "2026-04-20T19:28:48.967Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/da/ed6f772339cf29bd9a46def9d6db5084689eb574ee4d150ff704224c1ed8/ty-0.0.32-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8300caf35345498e9b9b03e550bba03cee8f5f5f8ab4c83c3b1ff1b7403b7d3a", size = 11280714, upload-time = "2026-04-20T19:28:51.516Z" },
+    { url = "https://files.pythonhosted.org/packages/da/9b/c6813987edf4816a40e0c8e408b555f97d3f267c7b3a1688c8bbdf65609c/ty-0.0.32-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:583c7094f4574b02f724db924f98b804d1387a0bd9405ecb5e078cc0f47fbcfb", size = 10638806, upload-time = "2026-04-20T19:28:29.651Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/d4/0cefcbd2ad0f3d51762ccf58e652ec7da146eb6ae34f87228f6254bbb8be/ty-0.0.32-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:e44ebe1bb4143a5628bc4db67ac0dfebe14594af671e4ee66f6f2e983da56501", size = 10726106, upload-time = "2026-04-20T19:29:06.3Z" },
+    { url = "https://files.pythonhosted.org/packages/32/ad/2c8a97f91f06311f4367400f7d13534bbda2522c73c99a3e4c0757dff9b8/ty-0.0.32-py3-none-musllinux_1_2_i686.whl", hash = "sha256:06f17ada3e069cba6148342ef88e9929156beca8473e8d4f101b68f66c75643e", size = 10872951, upload-time = "2026-04-20T19:28:34.077Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/68/42293f9248106dd51875120971a5cc6ea315c2c4dcfb8e59aa063aa0af26/ty-0.0.32-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e96e60fa556cec04f15d7ea62d2ceee5982bd389233e961ab9fd42304e278175", size = 11363334, upload-time = "2026-04-20T19:28:54.036Z" },
+    { url = "https://files.pythonhosted.org/packages/df/92/be9abf4d3e589ad5023e2ea965b93e204ec856420d46adf73c5c36c04678/ty-0.0.32-py3-none-win32.whl", hash = "sha256:2ff2ebb4986b24aebcf1444db7db5ca41b36086040e95eea9f8fb851c11e805c", size = 10260689, upload-time = "2026-04-20T19:28:56.541Z" },
+    { url = "https://files.pythonhosted.org/packages/14/61/dc86acea899349d2579cb8419aecedd83dc504d7d6a10df65eef546c8300/ty-0.0.32-py3-none-win_amd64.whl", hash = "sha256:ba7284a4a954b598c1b31500352b3ec1f89bff533825592b5958848226fdc7ee", size = 11255371, upload-time = "2026-04-20T19:28:39.917Z" },
+    { url = "https://files.pythonhosted.org/packages/43/01/beffec56d71ca25b343ede63adb076456b5b3e211f1c066452a44cd120b3/ty-0.0.32-py3-none-win_arm64.whl", hash = "sha256:7e10aadbdbda989a7d567ee6a37f8b98d4d542e31e3b190a2879fd581f75d658", size = 10658087, upload-time = "2026-04-20T19:28:59.286Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Co-authored-by: Copilot <copilot@github.com>

## Summary by Sourcery

Integrate the ty type checker into the project and refine type handling and Notion integration helpers.

New Features:
- Add ty as a development dependency and configure it for project-wide type checking via pyproject, pre-commit, and Just tasks.

Bug Fixes:
- Ensure betterproto2 Message instances are hashable in a safe way before using them with caching.
- Fix URL normalization helper to consistently return HTTPS URLs with simplified, string-only typing.
- Correct Notion icon handling to work with both text emojis and file/emoji wrapper types when updating pages.

Enhancements:
- Adjust Notion page abstraction to use a static method for building populated property dictionaries, simplifying its interface.

Build:
- Update pre-commit configuration to run ty and deptry via uv as local hooks with consistent Python tooling integration.